### PR TITLE
Wrong confirmations count in /tx

### DIFF
--- a/views/tx.jade
+++ b/views/tx.jade
@@ -18,7 +18,7 @@ block content
             th #{settings.locale.timestamp}
             th
         tbody
-          - var confirms = (blockcount - tx.blockindex);
+          - var confirms = (blockcount - tx.blockindex + 1);
           if confirms >= confirmations                
             tr.success
                 td #{confirms}


### PR DESCRIPTION
The block the transaction is in is counted as 1 confirmation, correct calculation is  "latest block height" - "tx block height" + 1